### PR TITLE
Box method invocation arguments sent across host proxy.

### DIFF
--- a/Clustering/ClusteringPhaseFactory.cs
+++ b/Clustering/ClusteringPhaseFactory.cs
@@ -22,15 +22,17 @@ namespace Dargon.Services.Clustering {
       private readonly PofStreamsFactory pofStreamsFactory;
       private readonly IHostSessionFactory hostSessionFactory;
       private readonly IClusteringConfiguration clusteringConfiguration;
+      private readonly MethodArgumentsConverter methodArgumentsConverter;
       private readonly ClusteringPhaseManager clusteringPhaseManager;
 
-      public ClusteringPhaseFactoryImpl(ICollectionFactory collectionFactory, IThreadingProxy threadingProxy, INetworkingProxy networkingProxy, PofStreamsFactory pofStreamsFactory, IHostSessionFactory hostSessionFactory, IClusteringConfiguration clusteringConfiguration, ClusteringPhaseManager clusteringPhaseManager) {
+      public ClusteringPhaseFactoryImpl(ICollectionFactory collectionFactory, IThreadingProxy threadingProxy, INetworkingProxy networkingProxy, PofStreamsFactory pofStreamsFactory, IHostSessionFactory hostSessionFactory, IClusteringConfiguration clusteringConfiguration, MethodArgumentsConverter methodArgumentsConverter, ClusteringPhaseManager clusteringPhaseManager) {
          this.collectionFactory = collectionFactory;
          this.threadingProxy = threadingProxy;
          this.networkingProxy = networkingProxy;
          this.pofStreamsFactory = pofStreamsFactory;
          this.hostSessionFactory = hostSessionFactory;
          this.clusteringConfiguration = clusteringConfiguration;
+         this.methodArgumentsConverter = methodArgumentsConverter;
          this.clusteringPhaseManager = clusteringPhaseManager;
       }
 
@@ -40,7 +42,7 @@ namespace Dargon.Services.Clustering {
       }
 
       public ClusteringPhase CreateHostPhase(LocalServiceContainer localServiceContainer, IListenerSocket listenerSocket) {
-         var hostContext = new HostContext(localServiceContainer);
+         var hostContext = new HostContext(methodArgumentsConverter, localServiceContainer);
          var phase = new HostPhase(collectionFactory, threadingProxy, hostSessionFactory, hostContext, listenerSocket);
          return phase;
       }
@@ -48,7 +50,7 @@ namespace Dargon.Services.Clustering {
       public ClusteringPhase CreateGuestPhase(LocalServiceContainer localServiceContainer, IConnectedSocket clientSocket) {
          var pofStream = pofStreamsFactory.CreatePofStream(clientSocket.Stream);
          var pofDispatcher = pofStreamsFactory.CreateDispatcher(pofStream);
-         var messageSender = new MessageSenderImpl(pofStream.Writer);
+         var messageSender = new MessageSenderImpl(pofStream.Writer, methodArgumentsConverter);
          var phase = new GuestPhase(
             this, 
             localServiceContainer, 

--- a/Clustering/Host/IHostContext.cs
+++ b/Clustering/Host/IHostContext.cs
@@ -7,27 +7,32 @@ using ItzWarty.Collections;
 namespace Dargon.Services.Clustering.Host {
    public interface IHostContext : IDisposable {
       Task<object> Invoke(Guid serviceGuid, string methodName, object[] methodArguments);
+      Task<object> Invoke(Guid serviceGuid, string methodName, MethodArgumentsDto methodArguments);
       void AddRemoteInvokable(IRemoteInvokable remoteInvokable);
       void RemoveRemoteInvokable(IRemoteInvokable remoteInvokable);
    }
 
    public interface IRemoteInvokable {
       Task<RemoteInvocationResult> TryRemoteInvoke(Guid serviceGuid, string methodName, object[] arguments);
+      Task<RemoteInvocationResult> TryRemoteInvoke(Guid serviceGuid, string methodName, MethodArgumentsDto argumentsDto);
    }
 
    public class HostContext : IHostContext {
       public IConcurrentSet<IRemoteInvokable> RemoteInvokables { get; set; }
+      private readonly MethodArgumentsConverter methodArgumentsConverter;
       private readonly LocalServiceContainer localServiceContainer;
       private readonly IConcurrentSet<IRemoteInvokable> remoteInvokables;
 
       public HostContext(
+         MethodArgumentsConverter methodArgumentsConverter, 
          LocalServiceContainer localServiceContainer
       ) : this(
+         methodArgumentsConverter, 
          localServiceContainer, 
-         new ConcurrentSet<IRemoteInvokable>()
-      ) {}
+         new ConcurrentSet<IRemoteInvokable>()) {}
 
-      public HostContext(LocalServiceContainer localServiceContainer, IConcurrentSet<IRemoteInvokable> remoteInvokables) {
+      public HostContext(MethodArgumentsConverter methodArgumentsConverter, LocalServiceContainer localServiceContainer, IConcurrentSet<IRemoteInvokable> remoteInvokables) {
+         this.methodArgumentsConverter = methodArgumentsConverter;
          this.localServiceContainer = localServiceContainer;
          this.remoteInvokables = remoteInvokables;
       }
@@ -39,6 +44,33 @@ namespace Dargon.Services.Clustering.Host {
                bool invocationSuccessful = false;
                foreach (var remoteInvokable in remoteInvokables) {
                   var invocation = await remoteInvokable.TryRemoteInvoke(serviceGuid, methodName, methodArguments);
+                  if (invocation.Success) {
+                     result = invocation.ReturnValue;
+                     invocationSuccessful = true;
+                     break;
+                  }
+               }
+
+               if (!invocationSuccessful) {
+                  throw new ServiceUnavailableException(serviceGuid, methodName);
+               }
+            }
+         } catch (Exception e) {
+            result = new PortableException(e);
+         }
+         return result;
+      }
+
+      public async Task<object> Invoke(Guid serviceGuid, string methodName, MethodArgumentsDto methodArgumentsDto) {
+         object result = null;
+         try {
+            object[] methodArguments;
+            if (methodArgumentsConverter.TryConvertFromDataTransferObject(methodArgumentsDto, out methodArguments) &&
+                localServiceContainer.TryInvoke(serviceGuid, methodName, methodArguments, out result)) {
+            } else {
+               bool invocationSuccessful = false;
+               foreach (var remoteInvokable in remoteInvokables) {
+                  var invocation = await remoteInvokable.TryRemoteInvoke(serviceGuid, methodName, methodArgumentsDto);
                   if (invocation.Success) {
                      result = invocation.ReturnValue;
                      invocationSuccessful = true;

--- a/Clustering/Host/IHostSessionFactory.cs
+++ b/Clustering/Host/IHostSessionFactory.cs
@@ -17,19 +17,21 @@ namespace Dargon.Services.Clustering.Host {
       private readonly ICollectionFactory collectionFactory;
       private readonly IPofSerializer pofSerializer;
       private readonly PofStreamsFactory pofStreamsFactory;
+      private readonly MethodArgumentsConverter methodArgumentsConverter;
 
-      public HostSessionFactory(IThreadingProxy threadingProxy, ICollectionFactory collectionFactory, IPofSerializer pofSerializer, PofStreamsFactory pofStreamsFactory) {
+      public HostSessionFactory(IThreadingProxy threadingProxy, ICollectionFactory collectionFactory, IPofSerializer pofSerializer, PofStreamsFactory pofStreamsFactory, MethodArgumentsConverter methodArgumentsConverter) {
          this.threadingProxy = threadingProxy;
          this.collectionFactory = collectionFactory;
          this.pofSerializer = pofSerializer;
          this.pofStreamsFactory = pofStreamsFactory;
+         this.methodArgumentsConverter = methodArgumentsConverter;
       }
 
       public IHostSession Create(IHostContext hostContext, IConnectedSocket socket) {
          var shutdownCancellationTokenSource = threadingProxy.CreateCancellationTokenSource();
          var pofStream = pofStreamsFactory.CreatePofStream(socket.Stream);
          var pofDispatcher = pofStreamsFactory.CreateDispatcher(pofStream);
-         var messageSender = new MessageSenderImpl(pofStream.Writer);
+         var messageSender = new MessageSenderImpl(pofStream.Writer, methodArgumentsConverter);
          var session = new HostSession(
             hostContext,
             shutdownCancellationTokenSource,

--- a/Dargon.Services.csproj
+++ b/Dargon.Services.csproj
@@ -35,15 +35,17 @@
     <Reference Include="Castle.Core">
       <HintPath>packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Dargon.PortableObjects">
-      <HintPath>packages\Dargon.PortableObjects.0.1.0\lib\net45\Dargon.PortableObjects.dll</HintPath>
+    <Reference Include="Dargon.PortableObjects, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\Dargon.PortableObjects.0.1.2\lib\net45\Dargon.PortableObjects.dll</HintPath>
     </Reference>
     <Reference Include="Dargon.PortableObjects.Streams, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>packages\Dargon.PortableObjects.Streams.0.1.2\lib\net45\Dargon.PortableObjects.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="ItzWarty.Commons">
-      <HintPath>packages\ItzWarty.Commons.0.1.1\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\ItzWarty.Commons.dll</HintPath>
+    <Reference Include="ItzWarty.Commons, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\ItzWarty.Commons.0.3.0\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\ItzWarty.Commons.dll</HintPath>
     </Reference>
     <Reference Include="ItzWarty.Proxies.Api">
       <HintPath>packages\ItzWarty.Proxies.Api.0.1.0\lib\net45\ItzWarty.Proxies.Api.dll</HintPath>

--- a/Dargon.Services.csproj
+++ b/Dargon.Services.csproj
@@ -83,6 +83,8 @@
     <Compile Include="Client\RemoteServiceProxyInvocationInterceptor.cs" />
     <Compile Include="Clustering\ClusteringPhaseManager.cs" />
     <Compile Include="Messaging\MessageSender.cs" />
+    <Compile Include="Messaging\MethodArgumentsConverter.cs" />
+    <Compile Include="Messaging\MethodArgumentsDto.cs" />
     <Compile Include="ServiceUnavailableException.cs" />
     <Compile Include="IClusteringConfiguration.cs" />
     <Compile Include="Clustering\Host\RemoteInvocationResult.cs" />

--- a/Dargon.Services.sln
+++ b/Dargon.Services.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22609.0
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dargon.Services.Tests", "libdsp.Tests\Dargon.Services.Tests.csproj", "{AD1F3318-0005-4D68-99D5-83279264BE82}"
 EndProject

--- a/IServiceClientFactory.cs
+++ b/IServiceClientFactory.cs
@@ -1,10 +1,13 @@
 ﻿using Castle.DynamicProxy;
+using Dargon.PortableObjects;
 using Dargon.PortableObjects.Streams;
 using Dargon.Services.Client;
 using Dargon.Services.Clustering;
 using Dargon.Services.Clustering.Host;
+using Dargon.Services.Messaging;
 using Dargon.Services.Server;
 using ItzWarty.Collections;
+using ItzWarty.IO;
 using ItzWarty.Networking;
 using ItzWarty.Threading;
 
@@ -15,31 +18,34 @@ namespace Dargon.Services {
 
    public class ServiceClientFactory : IServiceClientFactory {
       private readonly ProxyGenerator proxyGenerator;
+      private readonly IStreamFactory streamFactory;
       private readonly ICollectionFactory collectionFactory;
       private readonly IThreadingProxy threadingProxy;
       private readonly INetworkingProxy networkingProxy;
+      private readonly IPofSerializer pofSerializer;
       private readonly PofStreamsFactory pofStreamsFactory;
-      private readonly IHostSessionFactory hostSessionFactory;
-      private readonly InvokableServiceContextFactory invokableServiceContextFactory;
 
-      public ServiceClientFactory(ProxyGenerator proxyGenerator, ICollectionFactory collectionFactory, IThreadingProxy threadingProxy, INetworkingProxy networkingProxy, PofStreamsFactory pofStreamsFactory, IHostSessionFactory hostSessionFactory, InvokableServiceContextFactory invokableServiceContextFactory) {
+      public ServiceClientFactory(ProxyGenerator proxyGenerator, IStreamFactory streamFactory, ICollectionFactory collectionFactory, IThreadingProxy threadingProxy, INetworkingProxy networkingProxy, IPofSerializer pofSerializer, PofStreamsFactory pofStreamsFactory) {
          this.proxyGenerator = proxyGenerator;
+         this.streamFactory = streamFactory;
          this.collectionFactory = collectionFactory;
          this.threadingProxy = threadingProxy;
          this.networkingProxy = networkingProxy;
+         this.pofSerializer = pofSerializer;
          this.pofStreamsFactory = pofStreamsFactory;
-         this.hostSessionFactory = hostSessionFactory;
-         this.invokableServiceContextFactory = invokableServiceContextFactory;
       }
 
       public IServiceClient CreateOrJoin(IClusteringConfiguration clusteringConfiguration) {
          LocalServiceContainer localServiceContainer = new LocalServiceContainerImpl(collectionFactory);
          ClusteringPhaseManager clusteringPhaseManager = new ClusteringPhaseManagerImpl();
-         ClusteringPhaseFactory clusteringPhaseFactory = new ClusteringPhaseFactoryImpl(collectionFactory, threadingProxy, networkingProxy, pofStreamsFactory, hostSessionFactory, clusteringConfiguration, clusteringPhaseManager);
+         MethodArgumentsConverter methodArgumentsConverter = new MethodArgumentsConverter(streamFactory, pofSerializer);
+         IHostSessionFactory hostSessionFactory = new HostSessionFactory(threadingProxy, collectionFactory, pofSerializer, pofStreamsFactory, methodArgumentsConverter);
+         ClusteringPhaseFactory clusteringPhaseFactory = new ClusteringPhaseFactoryImpl(collectionFactory, threadingProxy, networkingProxy, pofStreamsFactory, hostSessionFactory, clusteringConfiguration, methodArgumentsConverter, clusteringPhaseManager);
          ClusteringPhase initialClusteringPhase = clusteringPhaseFactory.CreateIndeterminatePhase(localServiceContainer);
          clusteringPhaseManager.Transition(initialClusteringPhase);
          RemoteServiceInvocationValidatorFactory validatorFactory = new RemoteServiceInvocationValidatorFactoryImpl(collectionFactory);
          RemoteServiceProxyFactory remoteServiceProxyFactory = new RemoteServiceProxyFactoryImpl(proxyGenerator, validatorFactory, clusteringPhaseManager);
+         InvokableServiceContextFactory invokableServiceContextFactory = new InvokableServiceContextFactoryImpl(collectionFactory, methodArgumentsConverter);
          return new ServiceClient(collectionFactory, localServiceContainer, clusteringPhaseManager, invokableServiceContextFactory, remoteServiceProxyFactory);
       }
    }

--- a/Messaging/DspPofContext.cs
+++ b/Messaging/DspPofContext.cs
@@ -11,6 +11,7 @@ namespace Dargon.Services.Messaging {
          RegisterPortableObjectType(kPofIdentifierOffset + 4, typeof(X2XInvocationResult));
          RegisterPortableObjectType(kPofIdentifierOffset + 5, typeof(PortableException));
          RegisterPortableObjectType(kPofIdentifierOffset + 6, typeof(G2HServiceUpdate));
+         RegisterPortableObjectType(kPofIdentifierOffset + 7, typeof(MethodArgumentsDto));
       }
    }
 }

--- a/Messaging/MessageSender.cs
+++ b/Messaging/MessageSender.cs
@@ -1,12 +1,12 @@
 ﻿using Dargon.PortableObjects.Streams;
 using ItzWarty.Collections;
-using ItzWarty.IO;
 using System;
 using System.Threading.Tasks;
 
 namespace Dargon.Services.Messaging {
    public interface MessageSender : IDisposable {
       Task SendServiceInvocationAsync(uint invocationId, Guid serviceGuid, string methodName, object[] methodArguments);
+      Task SendServiceInvocationAsync(uint invocationId, Guid serviceGuid, string methodName, MethodArgumentsDto methodArgumentsDto);
       Task SendInvocationResultAsync(uint invocationId, object result);
       Task SendServiceBroadcastAsync(IReadOnlySet<Guid> serviceGuids);
       Task SendServiceUpdateAsync(IReadOnlySet<Guid> addedServices, IReadOnlySet<Guid> removedServices);
@@ -14,13 +14,20 @@ namespace Dargon.Services.Messaging {
 
    public class MessageSenderImpl : MessageSender {
       private readonly PofStreamWriter pofStreamWriter;
+      private readonly MethodArgumentsConverter methodArgumentsConverter;
 
-      public MessageSenderImpl(PofStreamWriter pofStreamWriter) {
+      public MessageSenderImpl(PofStreamWriter pofStreamWriter, MethodArgumentsConverter methodArgumentsConverter) {
          this.pofStreamWriter = pofStreamWriter;
+         this.methodArgumentsConverter = methodArgumentsConverter;
       }
 
       public Task SendServiceInvocationAsync(uint invocationId, Guid serviceGuid, string methodName, object[] methodArguments) {
-         var message = new X2XServiceInvocation(invocationId, serviceGuid, methodName, methodArguments);
+         var methodArgumentsDto = methodArgumentsConverter.ConvertToDataTransferObject(methodArguments);
+         return SendServiceInvocationAsync(invocationId, serviceGuid, methodName, methodArgumentsDto);
+      }
+
+      public Task SendServiceInvocationAsync(uint invocationId, Guid serviceGuid, string methodName, MethodArgumentsDto methodArgumentsDto) {
+         var message = new X2XServiceInvocation(invocationId, serviceGuid, methodName, methodArgumentsDto);
          return pofStreamWriter.WriteAsync(message);
       }
 

--- a/Messaging/MethodArgumentsConverter.cs
+++ b/Messaging/MethodArgumentsConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dargon.PortableObjects;
+using ItzWarty.IO;
+
+namespace Dargon.Services.Messaging {
+   public class MethodArgumentsConverter {
+      private readonly IStreamFactory streamFactory;
+      private readonly IPofSerializer pofSerializer;
+
+      public MethodArgumentsConverter(IStreamFactory streamFactory, IPofSerializer pofSerializer) {
+         this.streamFactory = streamFactory;
+         this.pofSerializer = pofSerializer;
+      }
+
+      public MethodArgumentsDto ConvertToDataTransferObject(object[] methodArguments) {
+         using (var outerMs = streamFactory.CreateMemoryStream()) {
+            pofSerializer.Serialize(outerMs.Writer, (object)methodArguments);
+            return new MethodArgumentsDto(outerMs.GetBuffer(), 0, (int)outerMs.Length);
+         }
+      }
+
+      public bool TryConvertFromDataTransferObject(MethodArgumentsDto dto, out object[] methodArguments) {
+         using (var ms = streamFactory.CreateMemoryStream(dto.Buffer, dto.Offset, dto.Length)) {
+            try {
+               methodArguments = (object[])pofSerializer.Deserialize(ms.Reader);
+               return true;
+            } catch (TypeNotFoundException) {
+               methodArguments = null;
+               return false;
+            }
+         }
+      }
+   }
+}

--- a/Messaging/MethodArgumentsDto.cs
+++ b/Messaging/MethodArgumentsDto.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using Dargon.PortableObjects;
+using ItzWarty;
+
+namespace Dargon.Services.Messaging {
+   public class MethodArgumentsDto : IPortableObject, IEquatable<MethodArgumentsDto> {
+      public MethodArgumentsDto() { }
+
+      public MethodArgumentsDto(byte[] buffer, int offset, int length) {
+         Buffer = buffer;
+         Offset = offset;
+         Length = length;
+      }
+
+      public byte[] Buffer { get; private set; }
+      public int Offset { get; private set; }
+      public int Length { get; private set; }
+
+      public void Serialize(IPofWriter writer) {
+         writer.AssignSlot(0, Buffer);
+         writer.WriteS32(1, Offset);
+         writer.WriteS32(2, Length);
+      }
+
+      public void Deserialize(IPofReader reader) {
+         Buffer = reader.ReadBytes(0);
+         Offset = reader.ReadS32(1);
+         Length = reader.ReadS32(2);
+      }
+
+      public bool Equals(MethodArgumentsDto other) {
+         return Length == other.Length &&
+                Buffer.Skip(Offset).SequenceEqual(other.Buffer.Skip(other.Offset));
+      }
+   }
+}

--- a/Messaging/X2XServiceInvocation.cs
+++ b/Messaging/X2XServiceInvocation.cs
@@ -7,7 +7,7 @@ namespace Dargon.Services.Messaging {
       private uint invocationId;
       private Guid serviceGuid;
       private string methodName;
-      private object[] methodArguments;
+      private MethodArgumentsDto methodArguments;
 
       public X2XServiceInvocation() { }
 
@@ -15,7 +15,7 @@ namespace Dargon.Services.Messaging {
          uint invocationId, 
          Guid serviceGuid, 
          string methodName, 
-         object[] methodArguments
+         MethodArgumentsDto methodArguments
       ) {
          this.invocationId = invocationId;
          this.serviceGuid = serviceGuid;
@@ -26,28 +26,28 @@ namespace Dargon.Services.Messaging {
       public uint InvocationId { get { return invocationId; } }
       public Guid ServiceGuid { get { return serviceGuid; } }
       public string MethodName { get { return methodName; } }
-      public object[] MethodArguments { get { return methodArguments; } }
+      public MethodArgumentsDto MethodArguments { get { return methodArguments; } }
 
       public void Serialize(IPofWriter writer) {
          writer.WriteU32(0, invocationId);
          writer.WriteGuid(1, serviceGuid);
          writer.WriteString(2, methodName);
-         writer.WriteCollection(3, methodArguments, true);
+         writer.WriteObject(3, methodArguments);
       }
 
       public void Deserialize(IPofReader reader) {
          invocationId = reader.ReadU32(0);
          serviceGuid = reader.ReadGuid(1);
          methodName = reader.ReadString(2);
-         methodArguments = reader.ReadArray<object>(3, true);
+         methodArguments = reader.ReadObject<MethodArgumentsDto>(3);
       }
 
-      public bool Equals(X2XServiceInvocation other) { 
-         return other != null && 
-                invocationId == other.invocationId && 
-                serviceGuid.Equals(other.serviceGuid) && 
-                methodName.Equals(other.MethodName) && 
-                methodArguments.SequenceEqual(other.methodArguments); 
+      public bool Equals(X2XServiceInvocation other) {
+         return other != null &&
+                invocationId == other.invocationId &&
+                serviceGuid.Equals(other.serviceGuid) &&
+                methodName.Equals(other.MethodName) &&
+                methodArguments.Equals(other.methodArguments);
       }
    }
 }

--- a/Server/InvokableServiceContextFactory.cs
+++ b/Server/InvokableServiceContextFactory.cs
@@ -1,5 +1,6 @@
 ﻿using ItzWarty.Collections;
 using System;
+using Dargon.Services.Messaging;
 
 namespace Dargon.Services.Server {
    public interface InvokableServiceContextFactory {
@@ -8,13 +9,15 @@ namespace Dargon.Services.Server {
 
    public class InvokableServiceContextFactoryImpl : InvokableServiceContextFactory {
       private readonly ICollectionFactory collectionFactory;
+      private readonly MethodArgumentsConverter methodArgumentsConverter;
 
-      public InvokableServiceContextFactoryImpl(ICollectionFactory collectionFactory) {
+      public InvokableServiceContextFactoryImpl(ICollectionFactory collectionFactory, MethodArgumentsConverter methodArgumentsConverter) {
          this.collectionFactory = collectionFactory;
+         this.methodArgumentsConverter = methodArgumentsConverter;
       }
 
       public InvokableServiceContext Create(object serviceImplementation, Type serviceInterface) {
-         return new InvokableServiceContextImpl(collectionFactory, serviceImplementation, serviceInterface);
+         return new InvokableServiceContextImpl(collectionFactory, methodArgumentsConverter, serviceImplementation, serviceInterface);
       }
    }
 }

--- a/Server/InvokableServiceContextImpl.cs
+++ b/Server/InvokableServiceContextImpl.cs
@@ -2,21 +2,26 @@ using Dargon.Services.Utilities;
 using ItzWarty;
 using ItzWarty.Collections;
 using System;
+using System.Data;
 using System.Reflection;
+using Dargon.Services.Messaging;
 
 namespace Dargon.Services.Server {
    public interface InvokableServiceContext {
       Guid Guid { get; }
       object HandleInvocation(string action, object[] arguments);
+      object HandleInvocation(string action, MethodArgumentsDto arguments);
    }
 
    public class InvokableServiceContextImpl : InvokableServiceContext {
+      private readonly MethodArgumentsConverter methodArgumentsConverter;
       private readonly object serviceImplementation;
       private readonly Type serviceInterface;
       private readonly Guid guid;
       private readonly IMultiValueDictionary<string, MethodInfo> methodsByName;
 
-      public InvokableServiceContextImpl(ICollectionFactory collectionFactory, object serviceImplementation, Type serviceInterface) {
+      public InvokableServiceContextImpl(ICollectionFactory collectionFactory, MethodArgumentsConverter methodArgumentsConverter, object serviceImplementation, Type serviceInterface) {
+         this.methodArgumentsConverter = methodArgumentsConverter;
          this.serviceImplementation = serviceImplementation;
          this.serviceInterface = serviceInterface;
 
@@ -46,6 +51,15 @@ namespace Dargon.Services.Server {
             }
          }
          throw new EntryPointNotFoundException("Could not find method " + action + " with given arguments");
+      }
+
+      public object HandleInvocation(string action, MethodArgumentsDto arguments) {
+         object[] methodArguments;
+         if (methodArgumentsConverter.TryConvertFromDataTransferObject(arguments, out methodArguments)) {
+            return HandleInvocation(action, methodArguments);
+         } else {
+            throw new PortableException(new Exception("Could not deserialize data in argument dto."));
+         }
       }
    }
 }

--- a/Server/LocalServiceContainer.cs
+++ b/Server/LocalServiceContainer.cs
@@ -3,6 +3,7 @@ using ItzWarty.Collections;
 using NLog;
 using System;
 using System.Collections.Generic;
+using Dargon.Services.Messaging;
 
 namespace Dargon.Services.Server {
    public interface LocalServiceContainer {
@@ -14,6 +15,7 @@ namespace Dargon.Services.Server {
 
       IEnumerable<Guid> EnumerateServiceGuids();
 
+      bool TryInvoke(Guid serviceGuid, string methodName, MethodArgumentsDto methodArguments, out object result);
       bool TryInvoke(Guid serviceGuid, string methodName, object[] methodArguments, out object result);
 
    }
@@ -55,6 +57,17 @@ namespace Dargon.Services.Server {
 
       public IEnumerable<Guid> EnumerateServiceGuids() {
          return serviceContextsByGuid.Keys;
+      }
+
+      public bool TryInvoke(Guid serviceGuid, string methodName, MethodArgumentsDto methodArgumentsDto, out object result) {
+         InvokableServiceContext invokableServiceContext;
+         if (!serviceContextsByGuid.TryGetValue(serviceGuid, out invokableServiceContext)) {
+            result = null;
+            return false;
+         } else {
+            result = invokableServiceContext.HandleInvocation(methodName, methodArgumentsDto);
+            return true;
+         }
       }
 
       public bool TryInvoke(Guid serviceGuid, string methodName, object[] methodArguments, out object result) {

--- a/libdsp.Tests/ClusteredServiceNodeFT.cs
+++ b/libdsp.Tests/ClusteredServiceNodeFT.cs
@@ -1,7 +1,6 @@
 ﻿using Castle.DynamicProxy;
 using Dargon.PortableObjects;
 using Dargon.PortableObjects.Streams;
-using Dargon.Services.Clustering.Host;
 using Dargon.Services.Messaging;
 using Dargon.Services.Server;
 using ItzWarty.Collections;
@@ -45,11 +44,11 @@ namespace Dargon.Services {
          ISocketFactory socketFactory = new SocketFactory(tcpEndPointFactory, networkingInternalFactory);
          INetworkingProxy networkingProxy = new NetworkingProxy(socketFactory, tcpEndPointFactory);
          IPofContext pofContext = new DspPofContext();
-         InvokableServiceContextFactory invokableServiceContextFactory = new InvokableServiceContextFactoryImpl(collectionFactory);
          IPofSerializer pofSerializer = new PofSerializer(pofContext);
          PofStreamsFactory pofStreamsFactory = new PofStreamsFactoryImpl(threadingProxy, streamFactory, pofSerializer);
-         IHostSessionFactory hostSessionFactory = new HostSessionFactory(threadingProxy, collectionFactory, pofSerializer, pofStreamsFactory);
-         serviceClientFactory = new ServiceClientFactory(proxyGenerator, collectionFactory, threadingProxy, networkingProxy, pofStreamsFactory, hostSessionFactory, invokableServiceContextFactory);
+         MethodArgumentsConverter methodArgumentsConverter = new MethodArgumentsConverter(streamFactory, pofSerializer);
+         InvokableServiceContextFactory invokableServiceContextFactory = new InvokableServiceContextFactoryImpl(collectionFactory, methodArgumentsConverter);
+         serviceClientFactory = new ServiceClientFactory(proxyGenerator, streamFactory, collectionFactory, threadingProxy, networkingProxy, pofSerializer, pofStreamsFactory);
       }
 
       [Fact]

--- a/libdsp.Tests/Dargon.Services.Tests.csproj
+++ b/libdsp.Tests/Dargon.Services.Tests.csproj
@@ -42,8 +42,9 @@
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Dargon.PortableObjects">
-      <HintPath>..\packages\Dargon.PortableObjects.0.1.0\lib\net45\Dargon.PortableObjects.dll</HintPath>
+    <Reference Include="Dargon.PortableObjects, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Dargon.PortableObjects.0.1.2\lib\net45\Dargon.PortableObjects.dll</HintPath>
     </Reference>
     <Reference Include="Dargon.PortableObjects.Streams, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -57,8 +58,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\ImpromptuInterface.6.2.2\lib\net40\ImpromptuInterface.dll</HintPath>
     </Reference>
-    <Reference Include="ItzWarty.Commons">
-      <HintPath>..\packages\ItzWarty.Commons.0.1.1\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\ItzWarty.Commons.dll</HintPath>
+    <Reference Include="ItzWarty.Commons, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ItzWarty.Commons.0.3.0\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\ItzWarty.Commons.dll</HintPath>
     </Reference>
     <Reference Include="ItzWarty.Proxies.Api">
       <HintPath>..\packages\ItzWarty.Proxies.Api.0.1.0\lib\net45\ItzWarty.Proxies.Api.dll</HintPath>

--- a/libdsp.Tests/packages.config
+++ b/libdsp.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Dargon.PortableObjects" version="0.1.0" targetFramework="net451" />
+  <package id="Dargon.PortableObjects" version="0.1.2" targetFramework="net451" />
   <package id="Dargon.PortableObjects.Streams" version="0.1.2" targetFramework="net451" />
   <package id="Dargon.TestUtilities" version="0.1.0" targetFramework="net451" />
   <package id="ImpromptuInterface" version="6.2.2" targetFramework="net451" />
-  <package id="ItzWarty.Commons" version="0.1.1" targetFramework="net451" />
+  <package id="ItzWarty.Commons" version="0.3.0" targetFramework="net451" />
   <package id="ItzWarty.Proxies.Api" version="0.1.0" targetFramework="net451" />
   <package id="ItzWarty.Proxies.Impl" version="0.1.1" targetFramework="net451" />
   <package id="Nito.AsyncEx" version="3.0.0" targetFramework="net451" />

--- a/packages.config
+++ b/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Dargon.PortableObjects" version="0.1.0" targetFramework="net45" />
+  <package id="Dargon.PortableObjects" version="0.1.2" targetFramework="net45" />
   <package id="Dargon.PortableObjects.Streams" version="0.1.2" targetFramework="net45" />
-  <package id="ItzWarty.Commons" version="0.1.1" targetFramework="net45" />
+  <package id="ItzWarty.Commons" version="0.3.0" targetFramework="net45" />
   <package id="ItzWarty.Proxies.Api" version="0.1.0" targetFramework="net45" />
   <package id="Nito.AsyncEx" version="3.0.0" targetFramework="net45" />
   <package id="NLog" version="3.1.0.0" targetFramework="net45" />


### PR DESCRIPTION
Currently, method invocation arguments are sent as portable arrays (object[]). If the message proxies through a host node from one guest client to another, and the host object lacks the POF Type definition for any of these method arguments, the message cannot be deserialized, is thrown away, and the connection closed.

The solution to this is to box the invocation arguments and transfer them as a byte array for dserialization at the remote endpoint.
